### PR TITLE
[feat] 내 서랍 ts+css(복구)

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -2,3 +2,4 @@ import './styles/main.css';
 import './components/Header.ts';
 import './components/Footer.ts';
 import './components/Navigation.ts';
+import './pages/drawer/drawer.ts';

--- a/src/pages/drawer/drawer.css
+++ b/src/pages/drawer/drawer.css
@@ -1,0 +1,160 @@
+/*
+ * ====================================================
+ * drawer.css - 전체 레이아웃 및 스타일
+ * ====================================================
+ */
+
+/* ----------------------------------------------------
+ * 1. 전역 설정 및 섹션 구조
+ * ----------------------------------------------------
+ */
+body {
+    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+    margin: 0;
+    padding: 16px;
+    background-color: #fff;
+    color: #333;
+    line-height: 1.4;
+    min-height: 100vh;
+}
+
+/* 동적 섹션 간 구분선 */
+.drawer_section_interest_author,
+.drawer_section_recently_viewed,
+.drawer_section_interest_post {
+    padding-bottom: 20px;
+    margin-bottom: 20px;
+    border-bottom: 1px solid #f0f0f0; 
+}
+
+/*
+ * ----------------------------------------------------
+ * 2. 섹션 헤더 스타일 (텍스트와 화살표를 양 끝으로 벌림)
+ * ----------------------------------------------------
+ */
+.drawer_section_header {
+    margin-bottom: 15px;
+}
+
+.drawer_section_header a {
+    /* Flexbox를 사용하여 텍스트와 이미지를 정렬 */
+    display: flex;
+    align-items: center;
+    justify-content: space-between; 
+    
+    /* 링크 영역 스타일 */
+    font-size: 1.1em;
+    font-weight: bold;
+    color: #333;
+    text-decoration: none;
+    width: 100%; 
+    padding: 0;
+}
+
+.drawer_section_header a span {
+    margin-right: 0; 
+}
+
+.drawer_section_header a img {
+    height: 14px; 
+    flex-shrink: 0;
+}
+
+/*
+ * ----------------------------------------------------
+ * 3. 작가 목록 스타일 (가로 스크롤)
+ * ----------------------------------------------------
+ */
+.drawer_author_list {
+    display: flex; 
+    overflow-x: auto; /* 가로 스크롤 허용 */
+    gap: 20px;
+    padding-bottom: 10px; 
+}
+
+/* 아래는 JS로 동적 생성될 항목에 적용될 스타일 (참고용) */
+.drawer_author_item { 
+    flex-shrink: 0; /* 축소 방지 */
+    width: 60px;
+    text-align: center;
+}
+.drawer_author_image { 
+    width: 60px; height: 60px; 
+    border-radius: 50%; 
+    background-color: #eee; /* placeholder 배경 */
+    margin-bottom: 5px;
+}
+.drawer_author_name { 
+    font-size: 0.85em; 
+    white-space: nowrap; 
+    overflow: hidden; 
+    text-overflow: ellipsis;
+}
+
+
+/*
+ * ----------------------------------------------------
+ * 4. 책/글 목록 스타일 (가로 스크롤)
+ * ----------------------------------------------------
+ */
+.drawer_book_list,
+.drawer_post_list {
+    display: flex; 
+    overflow-x: auto; 
+    gap: 12px; 
+    padding-bottom: 10px;
+}
+
+/* 아래는 JS로 동적 생성될 항목에 적용될 스타일 (참고용) */
+.drawer_book_item { 
+    flex-shrink: 0; 
+    width: 120px; /* 표지 폭 */
+}
+.drawer_book_cover { 
+    width: 100%; 
+    padding-top: 150%; /* 2:3 비율 (높이/너비) */
+    background-color: #eee;
+    border-radius: 4px; 
+    margin-bottom: 8px; 
+    position: relative;
+    box-shadow: 0 1px 3px rgba(0,0,0,0.1);
+}
+.drawer_book_title { 
+    font-size: 0.9em; 
+    font-weight: bold; 
+    white-space: nowrap; 
+    overflow: hidden; 
+    text-overflow: ellipsis;
+}
+.drawer_book_author { 
+    font-size: 0.8em; 
+    color: #666; 
+    white-space: nowrap; 
+    overflow: hidden; 
+    text-overflow: ellipsis;
+}
+
+
+/*
+ * ----------------------------------------------------
+ * 5. 내 브런치 섹션 스타일 (정적 콘텐츠)
+ * ----------------------------------------------------
+ */
+
+.drawer_brunch_item {
+    margin-bottom: 15px;
+    padding-top: 10px;
+}
+
+.drawer_brunch_title {
+    font-size: 1em;
+    font-weight: bold;
+    margin-bottom: 3px;
+    color: #333;
+}
+
+.drawer_brunch_info {
+    font-size: 0.9em;
+    color: #666;
+    margin-bottom: 2px;
+}

--- a/src/pages/drawer/drawer.html
+++ b/src/pages/drawer/drawer.html
@@ -1,67 +1,68 @@
 <!doctype html>
 <html lang="ko-KR">
-  <head>
-    <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <link rel="icon" type="image/svg+xml" href="/vite.svg" />
-    <title>내 서랍 | init 브런치</title>
-    <script type="module" src="/src/main.ts"></script>
-    <link rel="stylesheet" href="./drawer.css" />
-  </head>
-  <body>
-    <init-header></init-header>
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <link rel="icon" href="/public/icons/logo/logo_symbol.svg" type="image/svg" />
+  <title>내 서랍 | init 브런치</title>
+  <script type="module" src="/src/main.ts"></script>
+  <link rel="stylesheet" href="./drawer.css" />
+</head>
+<body>
+  <init-header></init-header>
 
-    <div class="drawer_section_interest_author">
-      <div class="drawer_section_header">
-        <a href="#">
-          <span>관심 작가</span>
-          <img src="/public/icons/arw-next-thin.svg" alt="관심 작가로 이동" />
-        </a>
-      </div>
-      <div class="drawer_author_list"></div>
+  <div class="drawer_section_interest_author">
+    <div class="drawer_section_header">
+      <a href="#">
+        <span>관심 작가</span>
+        <img src="/public/icons/arw-next-thin.svg" alt="관심 작가로 이동" />
+      </a>
     </div>
+    <div class="drawer_author_list"></div>
+  </div>
 
-    <div class="drawer_section_recently_viewed">
-      <div class="drawer_section_header">
-        <a href="#">
-          <span>최근 본</span>
-          <img src="/public/icons/arw-next-thin.svg" alt="최근 본으로 이동" />
-        </a>
-      </div>
-      <div class="drawer_book_list"></div>
+  <div class="drawer_section_recently_viewed">
+    <div class="drawer_section_header">
+      <a href="#">
+        <span>최근 본</span>
+        <img src="/public/icons/arw-next-thin.svg" alt="최근 본으로 이동" />
+      </a>
     </div>
+    <div class="drawer_book_list"></div>
+  </div>
 
-    <div class="drawer_section_interest_post">
-      <div class="drawer_section_header">
-        <a href="#">
-          <span>관심 글</span>
-          <img src="/public/icons/arw-next-thin.svg" alt="관심 글로 이동" />
-        </a>
-      </div>
-      <div class="drawer_post_list"></div>
+  <div class="drawer_section_interest_post">
+    <div class="drawer_section_header">
+      <a href="#">
+        <span>관심 글</span>
+        <img src="/public/icons/arw-next-thin.svg" alt="관심 글로 이동" />
+      </a>
     </div>
+    <div class="drawer_post_list"></div>
+  </div>
 
-    <div class="drawer_my_brunch_section">
-      <div class="drawer_section_header">
-        <a href="#">
-          <span>내 브런치</span>
-          <img src="/public/icons/arw-next-thin.svg" alt="내 브런치로 이동" />
-        </a>
-      </div>
+  <div class="drawer_my_brunch_section">
+    <div class="drawer_section_header">
+      <a href="#">
+        <span>내 브런치</span>
+        <img src="/public/icons/arw-next-thin.svg" alt="내 브런치로 이동" />
+      </a>
     </div>
+  </div>
 
-    <div class="drawer_brunch_item">
-      <div class="drawer_brunch_title">D-70, 30주</div>
-      <div class="drawer_brunch_info">별과 만나기까지 100일간의 기록</div>
-      <div class="drawer_brunch_info">Feb 05 / 2024</div>
-    </div>
+  <div class="drawer_brunch_item">
+    <div class="drawer_brunch_title">D-70, 30주</div>
+    <div class="drawer_brunch_info">별과 만나기까지 100일간의 기록</div>
+    <div class="drawer_brunch_info">Feb 05 / 2024</div>
+  </div>
 
-    <div class="drawer_brunch_item">
-      <div class="drawer_brunch_title">6 윤희 - 2</div>
-      <div class="drawer_brunch_info">낙원</div>
-    </div>
+  <div class="drawer_brunch_item">
+    <div class="drawer_brunch_title">6 윤희 - 2</div>
+    <div class="drawer_brunch_info">낙원</div>
+  </div>
 
-    <init-nav></init-nav>
-    <init-footer></init-footer>
-  </body>
+  <init-nav></init-nav>
+  <init-footer></init-footer>
+</body>
+
 </html>

--- a/src/pages/drawer/drawer.ts
+++ b/src/pages/drawer/drawer.ts
@@ -1,0 +1,264 @@
+/*
+  drawer.ts
+  - 공통 API 핸들러(apiGet)
+  - 공통 렌더러(renderList)
+  - 템플릿 분리
+  - 데이터 정규화(normalize)
+  - 안전한 초기화
+  - 기존 recordViewedPost 유지
+*/
+
+const CLIENT_ID = 'febc15-vanilla06-ecad';
+const API_BASE_URL = 'https://fesp-api.koyeb.app/market';
+
+// -----------------------
+// 타입 정의
+// -----------------------
+interface Author {
+  _id: string;
+  image: string;
+  name: string;
+}
+
+interface Post {
+  _id: string;
+  image: string;
+  title: string;
+  name: string;
+}
+
+interface MyPost {
+  _id: string;
+  title: string;
+  content: string;
+  createdAt: string;
+}
+
+// -----------------------
+// 유틸리티
+// -----------------------
+const getToken = (): string | null => localStorage.getItem('accessToken');
+
+const truncateContent = (content: string, limit = 20): string =>
+  content.length > limit ? content.substring(0, limit) + '...' : content;
+
+// 저장 관련: 최근 본 글 기록 (기존 함수 유지)
+export function recordViewedPost(postId: string) {
+  const historyJson = localStorage.getItem('recentViewedPosts') || '[]';
+  let history: string[];
+
+  try {
+    history = JSON.parse(historyJson);
+  } catch (e) {
+    history = [];
+    console.error('최근 본 글 기록 파싱 오류:', e);
+  }
+
+  history = history.filter((id) => id !== postId);
+  history.unshift(postId);
+  history = history.slice(0, 10);
+  localStorage.setItem('recentViewedPosts', JSON.stringify(history));
+}
+
+// -----------------------
+// 공통 API 함수
+// -----------------------
+async function apiGet<T>(path: string, needAuth = false): Promise<T | null> {
+  const headers: Record<string, string> = { 'client-id': CLIENT_ID };
+  if (needAuth) {
+    const token = getToken();
+    if (!token) return null;
+    headers['Authorization'] = `Bearer ${token}`;
+  }
+
+  try {
+    const res = await fetch(`${API_BASE_URL}${path}`, { headers });
+    if (!res.ok) {
+      console.error(`API 오류 ${res.status} ${path}`);
+      return null;
+    }
+    return (await res.json()) as T;
+  } catch (e) {
+    console.error('API 통신 실패:', e);
+    return null;
+  }
+}
+
+// -----------------------
+// 데이터 정규화
+// -----------------------
+function normalizeAuthor(raw: any): Author {
+  return {
+    _id: raw._id ?? raw.targetId ?? String(raw.id ?? ''),
+    image: raw.image ?? '/public/icons/user-placeholder.svg',
+    name: raw.name ?? raw.nickname ?? `작가_${raw._id ?? raw.targetId ?? 'unknown'}`,
+  };
+}
+
+function normalizePost(raw: any): Post {
+  return {
+    _id: raw._id ?? raw.targetId ?? String(raw.id ?? ''),
+    image: raw.image ?? '/public/icons/book-placeholder.svg',
+    title: raw.title ?? raw.name ?? '제목 없음',
+    name: raw.name ?? raw.authorName ?? '정보 없음',
+  };
+}
+
+function normalizeMyPost(raw: any): MyPost {
+  return {
+    _id: raw._id ?? String(raw.id ?? ''),
+    title: raw.title ?? '제목 없음',
+    content: raw.content ?? '',
+    createdAt: raw.createdAt ?? raw.date ?? '',
+  };
+}
+
+// -----------------------
+// 템플릿 함수
+// -----------------------
+const authorTemplate = (author: Author) => `
+  <a href="/author/${author._id}" class="drawer_author_item">
+    <div class="drawer_author_image" style="background-image: url(${author.image}); background-size: cover;"></div>
+    <div class="drawer_author_name">${author.name}</div>
+  </a>
+`;
+
+const postTemplate = (post: Post) => `
+  <a href="/post/${post._id}" class="drawer_book_item">
+    <div class="drawer_book_cover" style="background-image: url(${post.image}); background-size: cover;"></div>
+    <div class="drawer_book_title">${post.title}</div>
+    <div class="drawer_book_author">${post.name}</div>
+  </a>
+`;
+
+const myPostTemplate = (post: MyPost) => `
+  <a href="/post/${post._id}" class="drawer_brunch_item">
+    <div class="drawer_brunch_title">${post.title}</div>
+    <div class="drawer_brunch_info">${truncateContent(post.content)}</div>
+    <div class="drawer_brunch_info">${post.createdAt}</div>
+  </a>
+`;
+
+// -----------------------
+// 범용 렌더러
+// -----------------------
+function renderList<T>(selector: string, items: T[], emptyMessage: string, template: (item: T) => string) {
+  const container = document.querySelector(selector);
+  if (!container) return;
+
+  if (!items || items.length === 0) {
+    container.innerHTML = `<p class="drawer_no_data">${emptyMessage}</p>`;
+    return;
+  }
+
+  container.innerHTML = items.map(template).join('');
+}
+
+// -----------------------
+// 개별 fetch + render 함수들
+// -----------------------
+async function fetchInterestAuthors(): Promise<Author[]> {
+  const data = await apiGet<any[]>('/bookmarks/user', true);
+  if (!data) return [];
+  // API 스펙에 따라 매핑
+  return data.map(normalizeAuthor);
+}
+
+async function fetchInterestPosts(): Promise<Post[]> {
+  const data = await apiGet<any[]>('/bookmarks/post', true);
+  if (!data) return [];
+  return data.map(normalizePost);
+}
+
+async function fetchRecentlyViewedPosts(): Promise<Post[]> {
+  const historyJson = localStorage.getItem('recentViewedPosts') || '[]';
+  let postIds: string[];
+  try {
+    postIds = JSON.parse(historyJson);
+  } catch (e) {
+    postIds = [];
+    console.error('최근 본 글 파싱 오류:', e);
+  }
+
+  if (!postIds || postIds.length === 0) return [];
+
+  // ids 쿼리 길이 제한에 주의. 여기선 단순 호출
+  const res = await apiGet<any[]>(`/posts/list/by-ids?ids=${postIds.join(',')}`);
+  if (!res) {
+    // API 실패 시에도 사용자가 볼 수 있게 임시 id 기반 데이터를 반환
+    return postIds.map((id) => ({ _id: id, image: '/public/icons/book-placeholder.svg', title: `임시 제목 (${id})`, name: '정보 없음' } as Post));
+  }
+
+  // API가 반환한 순서가 보장되지 않으면 postIds 순서에 맞춰 정렬할 수 있음
+  const normalized = res.map(normalizePost);
+  // 순서 맞추기 (postIds 기준)
+  const byId = new Map(normalized.map((p) => [p._id, p]));
+  return postIds.map((id) => byId.get(id) ?? { _id: id, image: '/public/icons/book-placeholder.svg', title: `임시 제목 (${id})`, name: '정보 없음' });
+}
+
+async function fetchMyPosts(): Promise<MyPost[]> {
+  // 현재는 하드코딩된 예시. 실제 API가 생기면 apiGet 사용
+  const sample = [
+    { _id: 'my1', title: 'D-70, 30주', content: '별과 만나기까지 100일간의 기록', createdAt: 'Feb 05 / 2024' },
+    { _id: 'my2', title: '6 윤희 - 2', content: '낙원', createdAt: 'Jan 20 / 2024' },
+  ];
+  return sample.map(normalizeMyPost);
+}
+
+// -----------------------
+// 렌더링 호출부
+// -----------------------
+function renderInterestAuthors(authors: Author[]) {
+  renderList('.drawer_author_list', authors, '관심 작가가 없습니다.', authorTemplate);
+}
+
+function renderRecentlyViewedPosts(posts: Post[]) {
+  renderList('.drawer_book_list', posts, '최근 본 글이 없습니다.', postTemplate);
+}
+
+function renderInterestPosts(posts: Post[]) {
+  renderList('.drawer_post_list', posts, '관심 글이 없습니다.', postTemplate);
+}
+
+function renderMyPosts(posts: MyPost[]) {
+  const sectionSelector = '.drawer_my_brunch_section';
+  const section = document.querySelector(sectionSelector);
+  if (!section) return;
+
+  // 기존 아이템 제거 (안정성)
+  const existingItems = section.querySelectorAll('.drawer_brunch_item');
+  existingItems.forEach((it) => it.remove());
+
+  if (!posts || posts.length === 0) {
+    section.insertAdjacentHTML('beforeend', `<p class="drawer_no_data">작성한 글이 없습니다.</p>`);
+    return;
+  }
+
+  const html = posts.map(myPostTemplate).join('');
+  section.insertAdjacentHTML('beforeend', html);
+}
+
+// -----------------------
+// 초기화
+// -----------------------
+export async function initializeDrawer(): Promise<void> {
+  const [authors, recent, interest, myPosts] = await Promise.all([
+    fetchInterestAuthors(),
+    fetchRecentlyViewedPosts(),
+    fetchInterestPosts(),
+    fetchMyPosts(),
+  ]);
+
+  renderInterestAuthors(authors ?? []);
+  renderRecentlyViewedPosts(recent ?? []);
+  renderInterestPosts(interest ?? []);
+  renderMyPosts(myPosts ?? []);
+
+  console.log('Drawer UI 초기화 완료.');
+  if (!getToken()) {
+    console.warn('⚠️ 액세스 토큰이 없어 관심 작가/글 데이터는 빈 목록이 표시됩니다.');
+  }
+}
+
+// 자동 초기화 (페이지 로드 시)
+initializeDrawer().catch((e) => console.error('초기화 중 오류:', e));


### PR DESCRIPTION
1. 공통 API 핸들러 및 렌더링 로직 구현
* `apiGet<T>`**공통함수** : 인증(`needAuth`)여부에 따하 `client-id`와 `Authorization`헤더를 조건부로 추가하고, 모든 API 호출의 **오류처리(HTTP 상태 코드 및 통신 실패)** 를 중앙 집중화하여 코드 안정성 높힘.
* **데이터 정규화** (`normalize...`) : API 응답 필드와 무관하게 사용된 데이터 구조를 통일하여 렌더링 코드 의존성 낮춤.
* **범용 렌더러(`renderList`)  : 목록 렌더링 로직을 일반화하고, **템플릿 함수**를 분리하여 재사용성 높힘.

2. 최근 본 글(`recentViewedPosts`) 기능 구현
* **기록 유지** : 기존 `recordViewPost`함수를 유지하여 게시글 ID를 `localStorage`에 기록
* **조회 로직** : `fetchRecentlyViewedPosts`함수가 `localStorage`의 ID 목록을 읽어와 **게시글 조회 API** (가상의 `/posts/list/by-ids`)호출
* **순서 보장** : 조회된 게시글 목록을 'localStorage`에 기록된 **최신순**(`postIds`)에 맞춰 정렬하여 반환

3. 안전한 초기화
* **병렬 처리** : `initializeDrawer`에서 모든 데이터(`author`, `recent`, `interest`, `myPost`)  요청을 `Pramise.all`을 사용하여 **병렬로 처리**하도록 구성
* **인증 경고** : 토큰 부재 시 콘솔에 **명확한 경고메세지**를 출력하여 문제 원인을 바로 인지 할 수 있도록 처리.

📌 로그인 상태에 따라 **관심 작가** 및 **관심 글** 섹션이 401 오류를 회피하고 빈 목록을 표시하도록 로직 구성